### PR TITLE
[1-min] Fix output path for type defs

### DIFF
--- a/packages/react-signature-frame/package.json
+++ b/packages/react-signature-frame/package.json
@@ -5,7 +5,7 @@
   "author": "Anvil Foundry Inc.",
   "license": "MIT",
   "main": "dist/index.js",
-  "types": "./types/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc && webpack --mode production",
     "build:changelog": "yarn auto-changelog",

--- a/packages/react-signature-frame/tsconfig.json
+++ b/packages/react-signature-frame/tsconfig.json
@@ -23,7 +23,7 @@
     // Types should go into this directory.
     // Removing this would place the .d.ts files
     // next to the .js files
-    "outDir": "types",
+    "outDir": "dist",
     // go to js file when using IDE functions like
     // "Go to Definition" in VSCode
     "declarationMap": true,

--- a/packages/react-signature-modal/package.json
+++ b/packages/react-signature-modal/package.json
@@ -5,7 +5,7 @@
   "author": "Anvil Foundry Inc.",
   "license": "MIT",
   "main": "dist/index.js",
-  "types": "./types/react-signature-modal/src/index.d.ts",
+  "types": "dist/react-signature-modal/src/index.d.ts",
   "scripts": {
     "build": "tsc && webpack --mode production",
     "build:changelog": "yarn auto-changelog",

--- a/packages/react-signature-modal/tsconfig.json
+++ b/packages/react-signature-modal/tsconfig.json
@@ -23,7 +23,7 @@
     // Types should go into this directory.
     // Removing this would place the .d.ts files
     // next to the .js files
-    "outDir": "types",
+    "outDir": "dist",
     // go to js file when using IDE functions like
     // "Go to Definition" in VSCode
     "declarationMap": true,


### PR DESCRIPTION
## Description of the change

Fixes output path for types files (*.d.ts). `lerna` builds and publishes things that are in the `dist` directory and types were not going there. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes <add Issue here, can be in format #xx>

## Dev Checklist

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] No previous tests unrelated to the changed code fail in development
