### PR TITLE
New `@anvilco/anvil-embed-frame` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 
 # Anvil React UI Components
 
-This repo contains multiple React components used to embed [Anvil E-signatures](https://www.useanvil.com/docs/api/e-signatures) into your app or website. Pick and choose the component that best suits your use case, integrate it into your code, and the components will take care of the rest.
+This repo contains multiple React components used to embed [Anvil E-signatures](https://www.useanvil.com/docs/api/e-signatures), [Workflows](https://www.useanvil.com/docs/api/workflows#embedding-workflows-in-your-app), and editors into your app or website. Pick and choose the component that best suits your use case, integrate it into your code, and the components will take care of the rest.
 
-The following components will embed the Anvil signing process in an `iframe` within your app or website. To enable, go to your organization's settings in Anvil, and enable "Iframe Embedding" in the API section. `EtchPackets` [created with `isTest: true`](https://www.useanvil.com/docs/api/e-signatures#testing-your-packet-configuration) are embeddable without contacting us.
+The following components will embed the Anvil product in an `iframe` within your app or website. To enable, go to your organization's settings in Anvil, and enable "Iframe Embedding" in the API section. Test `EtchPackets` [created with `isTest: true`](https://www.useanvil.com/docs/api/e-signatures#testing-your-packet-configuration)and `Workflow submissions` are embeddable without contacting us.
 
-* [AnvilSignatureFrame](#AnvilSignatureFrame) - an `iframe` component with lifecycle callbacks for embedding Anvil e-signatures.
-* [AnvilSignatureModal](#AnvilSignatureModal) - a modal popup window component with lifecycle callbacks for embedding Anvil e-signatures.
+* [AnvilEmbedFrame](#AnvilEmbedFrame) - an `iframe` component with a simple `onEvent` callback for embedding Etch e-sign, Workflows, or editors.
+* (Deprecated) [AnvilSignatureFrame](#AnvilSignatureFrame) - an `iframe` component with lifecycle callbacks for embedding Anvil e-signatures.
+* (Deprecated) [AnvilSignatureModal](#AnvilSignatureModal) - a modal popup window component with lifecycle callbacks for embedding Anvil e-signatures.
 
-See the [live demo](https://esign-demo.useanvil.com/) and open-source [demo repository](https://github.com/anvilco/anvil-e-signature-api-node-example) for a usage example of both components.
+See the [live demo](https://esign-demo.useanvil.com/) and open-source [demo repository](https://github.com/anvilco/anvil-e-signature-api-node-example) for a usage example of `AnvilSignatureFrame` and `AnvilSignatureModal`.
 
 ## What is Anvil?
 
@@ -23,7 +24,34 @@ See the [live demo](https://esign-demo.useanvil.com/) and open-source [demo repo
 
 Learn more on our [Anvil developer page](https://www.useanvil.com/developers).
 
-## AnvilSignatureFrame
+## AnvilEmbedFrame
+
+A very minimal component that allows you to embed Anvil into your app with an `iframe`. It will give you information via the `onEvent` callback.
+
+### Usage
+
+See the [AnvilEmbedFrame README](./packages/anvil-embed-frame/README.md) for full details.
+
+```sh
+yarn add @anvilco/anvil-embed-frame
+```
+
+```sh
+npm install @anvilco/anvil-embed-frame
+```
+
+```js
+import AnvilEmbedFrame from '@anvilco/anvil-embed-frame'
+
+<AnvilEmbedFrame
+  iframeURL={etchSignURL || workflowURL || editorURL}
+  onEvent={(event) => console.log('Event object:', event)}
+  className="anvil-embed-frame"
+/>
+```
+
+
+## (Deprecated) AnvilSignatureFrame
 
 A very minimal component that allows you to embed Anvil e-signatures in your app with an `iframe`. It will give you information via callbacks through the signing process lifecycle.
 
@@ -54,7 +82,7 @@ import AnvilSignatureFrame from '@anvilco/react-signature-frame'
 ```
 
 
-## AnvilSignatureModal
+## (Deprecated) AnvilSignatureModal
 
 A minimal modal component that allows you to embed Anvil e-signatures via a modal popup in your app. It will give you information via callbacks through the signing process lifecycle. Compatible with mobile viewports with minimal dependencies.
 
@@ -95,7 +123,7 @@ import '@anvilco/react-signature-modal/dist/styles.css'
 
 ## Notes
 
-* Please contact us at [support@useanvil.com](mailto:support@useanvil.com) to enable iframe embedded signing for production signature packets.
+* Please contact us at [support@useanvil.com](mailto:support@useanvil.com) to enable iframe embedding for editors.
 * React >= v16.0 required.
 
 ## Bugs

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This repo contains multiple React components used to embed [Anvil E-signatures](
 The following components will embed the Anvil product in an `iframe` within your app or website. To enable, go to your organization's settings in Anvil, and enable "Iframe Embedding" in the API section. Test `EtchPackets` [created with `isTest: true`](https://www.useanvil.com/docs/api/e-signatures#testing-your-packet-configuration)and `Workflow submissions` are embeddable without contacting us.
 
 * [AnvilEmbedFrame](#AnvilEmbedFrame) - an `iframe` component with a simple `onEvent` callback for embedding Etch e-sign, Workflows, or editors.
+* [AnvilSignatureModal](#AnvilSignatureModal) - a modal popup window component with lifecycle callbacks for embedding Anvil e-signatures.
 * (Deprecated) [AnvilSignatureFrame](#AnvilSignatureFrame) - an `iframe` component with lifecycle callbacks for embedding Anvil e-signatures.
-* (Deprecated) [AnvilSignatureModal](#AnvilSignatureModal) - a modal popup window component with lifecycle callbacks for embedding Anvil e-signatures.
 
 See the [live demo](https://esign-demo.useanvil.com/) and open-source [demo repository](https://github.com/anvilco/anvil-e-signature-api-node-example) for a usage example of `AnvilSignatureFrame` and `AnvilSignatureModal`.
 
@@ -82,7 +82,7 @@ import AnvilSignatureFrame from '@anvilco/react-signature-frame'
 ```
 
 
-## (Deprecated) AnvilSignatureModal
+## AnvilSignatureModal
 
 A minimal modal component that allows you to embed Anvil e-signatures via a modal popup in your app. It will give you information via callbacks through the signing process lifecycle. Compatible with mobile viewports with minimal dependencies.
 

--- a/packages/anvil-embed-frame/.babelrc.js
+++ b/packages/anvil-embed-frame/.babelrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../.babelrc.js')

--- a/packages/anvil-embed-frame/.npmignore
+++ b/packages/anvil-embed-frame/.npmignore
@@ -1,0 +1,4 @@
+.babelrc
+webpack.config.js
+*.tgz
+src

--- a/packages/anvil-embed-frame/README.md
+++ b/packages/anvil-embed-frame/README.md
@@ -1,0 +1,89 @@
+# AnvilEmbedFrame
+
+A very minimal component that allows you to embed Anvil [Etch e-signatures](https://www.useanvil.com/docs/api/e-signatures#embedding-the-signing-ui-in-an-iframe) and [Workflows](https://www.useanvil.com/docs/api/workflows#embedding-workflows-in-your-app) in your app with an `iframe`. It will give you information via callbacks.
+
+See the Etch e-sign [live demo](https://esign-demo.useanvil.com/) and open-source [demo repository](https://github.com/anvilco/anvil-e-signature-api-node-example) for a Etch e-sign usage example.
+
+## What is Anvil?
+
+[Anvil](https://www.useanvil.com/developers) provides easy APIs for all things paperwork.
+
+1. [PDF filling API](https://www.useanvil.com/products/pdf-filling-api/) - fill out a PDF template with a web request and structured JSON data.
+2. [PDF generation API](https://www.useanvil.com/products/pdf-generation-api/) - send markdown or HTML and Anvil will render it to a PDF.
+3. [Etch E-sign with API](https://www.useanvil.com/products/etch/) - customizable, embeddable, e-signature platform with an API to control the signing process end-to-end.
+4. [Anvil Workflows (w/ API)](https://www.useanvil.com/products/workflows/) - Webforms + PDF + E-sign with a powerful no-code builder. Easily collect structured data, generate PDFs, and request signatures.
+
+Learn more on our [Anvil developer page](https://www.useanvil.com/developers).
+
+## Usage
+
+```sh
+yarn add @anvilco/anvil-embed-frame
+```
+
+```sh
+npm install @anvilco/anvil-embed-frame
+```
+
+```js
+import AnvilEmbedFrame from '@anvilco/anvil-embed-frame'
+
+<AnvilEmbedFrame
+  iframeURL={etchSignURL || workflowURL}
+  onEvent={(event) => console.log('Event object:', event)}
+  className="anvil-embed-frame"
+/>
+```
+
+## Props
+
+### iframeURL
+
+*String (required)* - A URL to the Anvil page you'd like to embed.
+For Etch e-sign, [refer to these docs](https://www.useanvil.com/docs/api/e-signatures#embedding-the-signing-ui-in-an-iframe) for instructions on generating the signing URL.
+For Workflows, [refer to these docs](https://www.useanvil.com/docs/api/workflows#embedding-workflows-in-your-app) for instructions on retrieving the Workflow URL.
+
+### onEvent
+
+*Function* - This function is called when an event is triggered.
+Possible event types for Etch e-sign include: `signerComplete`, `signerError`
+Possible event types for Workflwos include: `forgeSubmitPage`, `forgeComplete`
+
+Defaults to `() => {}`
+
+### enableDefaultStyles
+
+*Boolean* - Set to false to disable the default inline styles of the component.
+
+Defaults to `true`.
+
+### scroll
+
+*String* - Set scroll to the iframe
+
+* `auto` - scrolls the window to the iframe when mounted
+* `smooth` smoothly scrolls the window to the iframe when mounted
+* `null` - disables scrolling
+
+## Styling
+
+Customize the component by setting the `enableDefaultStyles` prop to false, then import CSS or pass in inline styles. Override IDs or classNames by passing them in as props.
+
+## Anvil Documentation
+
+* [Get started with Anvil API](https://www.useanvil.com/docs/api/getting-started)
+* [Etch E-sign API](https://www.useanvil.com/docs/api/e-signatures)
+* [Workflows API](https://www.useanvil.com/docs/api/workflows)
+
+## Notes
+
+* To enable iframe embedding, go to your organization's settings in Anvil, and enable "Iframe Embedding" in the API section.
+* React >= v16.0 required.
+
+## Bugs
+
+Please file an issue for bugs, missing documentation, or unexpected behavior.
+
+## Questions or Feedback
+
+Please email us at [support@useanvil.com](mailto:support@useanvil.com).

--- a/packages/anvil-embed-frame/README.md
+++ b/packages/anvil-embed-frame/README.md
@@ -1,8 +1,8 @@
 # AnvilEmbedFrame
 
-A very minimal component that allows you to embed Anvil [Etch e-signatures](https://www.useanvil.com/docs/api/e-signatures#embedding-the-signing-ui-in-an-iframe) and [Workflows](https://www.useanvil.com/docs/api/workflows#embedding-workflows-in-your-app) in your app with an `iframe`. It will give you information via callbacks.
+A very minimal component that allows you to embed Anvil [Etch e-signatures](https://www.useanvil.com/docs/api/e-signatures#embedding-the-signing-ui-in-an-iframe), [Workflows](https://www.useanvil.com/docs/api/workflows#embedding-workflows-in-your-app), and editors into your app with an `iframe`. It will give you information via callback `onEvent`.
 
-See the Etch e-sign [live demo](https://esign-demo.useanvil.com/) and open-source [demo repository](https://github.com/anvilco/anvil-e-signature-api-node-example) for a Etch e-sign usage example.
+See the Etch e-sign [live demo](https://esign-demo.useanvil.com/) and open-source [demo repository](https://github.com/anvilco/anvil-e-signature-api-node-example) for an embedded Etch e-sign usage example.
 
 ## What is Anvil?
 
@@ -29,7 +29,7 @@ npm install @anvilco/anvil-embed-frame
 import AnvilEmbedFrame from '@anvilco/anvil-embed-frame'
 
 <AnvilEmbedFrame
-  iframeURL={etchSignURL || workflowURL}
+  iframeURL={etchSignURL || workflowURL || editorURL}
   onEvent={(event) => console.log('Event object:', event)}
   className="anvil-embed-frame"
 />
@@ -53,6 +53,11 @@ Example
 // For Workflows
 <AnvilEmbedFrame
   iframeURL="https://app.useanvil.com/weld/my-org/my-workflow"
+/>
+
+// For PDF Template, Etch e-sign packet, or Workflow editor
+<AnvilEmbedFrame
+  iframeURL="https://app.useanvil.com/auth/tokenized/login?token=tiORV2IH2sgTG72ih05n"
 />
 ```
 
@@ -91,6 +96,7 @@ Customize the component by setting the `enableDefaultStyles` prop to false, then
 ## Notes
 
 * To enable iframe embedding, go to your organization's settings in Anvil, and enable "Iframe Embedding" in the API section.
+* Please contact us at [support@useanvil.com](mailto:support@useanvil.com) to enable iframe embedding for editors.
 * React >= v16.0 required.
 
 ## Bugs
@@ -100,3 +106,7 @@ Please file an issue for bugs, missing documentation, or unexpected behavior.
 ## Questions or Feedback
 
 Please email us at [support@useanvil.com](mailto:support@useanvil.com).
+
+## License
+
+MIT

--- a/packages/anvil-embed-frame/README.md
+++ b/packages/anvil-embed-frame/README.md
@@ -54,11 +54,6 @@ Example
 <AnvilEmbedFrame
   iframeURL="https://app.useanvil.com/weld/my-org/my-workflow"
 />
-
-// For PDF Template, Etch e-sign packet, or Workflow editor
-<AnvilEmbedFrame
-  iframeURL="https://app.useanvil.com/auth/tokenized/login?token=tiORV2IH2sgTG72ih05n"
-/>
 ```
 
 ### onEvent

--- a/packages/anvil-embed-frame/README.md
+++ b/packages/anvil-embed-frame/README.md
@@ -43,13 +43,26 @@ import AnvilEmbedFrame from '@anvilco/anvil-embed-frame'
 For Etch e-sign, [refer to these docs](https://www.useanvil.com/docs/api/e-signatures#embedding-the-signing-ui-in-an-iframe) for instructions on generating the signing URL.
 For Workflows, [refer to these docs](https://www.useanvil.com/docs/api/workflows#embedding-workflows-in-your-app) for instructions on retrieving the Workflow URL.
 
+Example
+```js
+// Etch e-signatures
+<AnvilEmbedFrame
+  iframeURL="https://app.useanvil.com/api/etch/verify/QL3RjmpXWBD4W6YCHSLr?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzaWduZXJJZCI6MTg3LCJjbGllbnRVc2VySWQiOiJzaWduZXIxIiwiY3JlYXRlZEF0IjoxNjY0NTY4NTkyNTk0LCJleHRyYSI6IkNVQlIiLCJpYXQiOjE2NjQ1Njg1OTIsImV4cCI6MTY2NDY1NDk5Mn0.RMpoBXdAU5k6ozX3y2xoI8ykqx2BXycIKNX7Kq0EFFs"
+/>
+
+// For Workflows
+<AnvilEmbedFrame
+  iframeURL="https://app.useanvil.com/weld/my-org/my-workflow"
+/>
+```
+
 ### onEvent
 
 *Function* - This function is called when an event is triggered.
 Possible event types for Etch e-sign include: `signerComplete`, `signerError`
 Possible event types for Workflwos include: `forgeSubmitPage`, `forgeComplete`
 
-Defaults to `() => {}`
+Defaults to `(eventObject) => {}`
 
 ### enableDefaultStyles
 

--- a/packages/anvil-embed-frame/package.json
+++ b/packages/anvil-embed-frame/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@anvilco/anvil-embed-frame",
+  "version": "1.0.0",
+  "description": "The AnvilEmbedFrame React component for embedded Etch signatures and Workflows.",
+  "author": "Anvil Foundry Inc.",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "webpack --mode production",
+    "build:changelog": "yarn auto-changelog",
+    "pack": "yarn pack",
+    "version": "yarn build:changelog && git add CHANGELOG.md",
+    "test": "yarn mocha --config ./test/mocha.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/anvilco/react-ui.git"
+  },
+  "homepage": "https://github.com/anvilco/react-ui#readme",
+  "bugs": {
+    "url": "https://github.com/anvilco/react-ui/issues",
+    "email": "support@useanvil.com"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "@anvilco:registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "keywords": [
+    "signature",
+    "documents",
+    "pdf",
+    "iframe",
+    "workflow"
+  ],
+  "devDependencies": {
+    "prop-types": "^15.8.1",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  },
+  "peerDependencies": {
+    "prop-types": "^15.6.0",
+    "react": ">=16",
+    "react-dom": ">=16"
+  },
+  "auto-changelog": {
+    "output": "CHANGELOG.md",
+    "template": "../../changelog-template.hbs",
+    "unreleased": false,
+    "commitLimit": true,
+    "tagPrefix": "@anvilco/anvil-embed-frame@",
+    "breakingPattern": "BREAKING CHANGE:"
+  }
+}

--- a/packages/anvil-embed-frame/src/index.js
+++ b/packages/anvil-embed-frame/src/index.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+class AnvilEmbedFrame extends React.Component {
+  constructor (props) {
+    super(props)
+    this.iframeRef = React.createRef()
+  }
+
+  componentDidMount () {
+    const { scroll } = this.props
+    if (scroll) this.iframeRef.current.scrollIntoView({ behavior: scroll })
+    window.addEventListener('message', this.handleEvent)
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener('message', this.handleEvent)
+  }
+
+  handleEvent = ({ origin, data }) => {
+    const { anvilURL, onEvent } = this.props
+    if (anvilURL !== origin) return
+    if (typeof data === 'object') {
+      onEvent(data)
+    }
+  }
+
+  render () {
+    const { iframeURL, onEvent, anvilURL, enableDefaultStyles, scroll, ...others } = this.props
+    return (
+      <iframe
+        id="anvil-embed-frame"
+        name="Anvil Embed Frame"
+        title="Anvil Embed Frame"
+        {...others} // props above may be overriden
+        src={iframeURL}
+        ref={this.iframeRef}
+        style={enableDefaultStyles
+          ? {
+              width: '80vw',
+              height: '85vh',
+              maxWidth: '1200px',
+              borderStyle: 'groove',
+            }
+          : undefined}
+      >
+        <p id="anvil-iframe-warning">Your browser does not support iframes.</p>
+      </iframe>
+    )
+  }
+}
+
+AnvilEmbedFrame.defaultProps = {
+  onEvent: () => {},
+  anvilURL: 'https://app.useanvil.com',
+  enableDefaultStyles: true,
+}
+
+AnvilEmbedFrame.propTypes = {
+  iframeURL: PropTypes.string.isRequired,
+  onEvent: PropTypes.func,
+  anvilURL: PropTypes.string,
+  enableDefaultStyles: PropTypes.bool,
+  scroll: PropTypes.oneOf(['auto', 'smooth']),
+}
+
+export default AnvilEmbedFrame

--- a/packages/anvil-embed-frame/src/index.js
+++ b/packages/anvil-embed-frame/src/index.js
@@ -32,9 +32,6 @@ class AnvilEmbedFrame extends React.Component {
         id="anvil-embed-frame"
         name="Anvil Embed Frame"
         title="Anvil Embed Frame"
-        {...others} // props above may be overriden
-        src={iframeURL}
-        ref={this.iframeRef}
         style={enableDefaultStyles
           ? {
               width: '80vw',
@@ -43,6 +40,9 @@ class AnvilEmbedFrame extends React.Component {
               borderStyle: 'groove',
             }
           : undefined}
+        {...others} // props above may be overriden
+        src={iframeURL}
+        ref={this.iframeRef}
       >
         <p id="anvil-iframe-warning">Your browser does not support iframes.</p>
       </iframe>

--- a/packages/anvil-embed-frame/test/.eslintrc.js
+++ b/packages/anvil-embed-frame/test/.eslintrc.js
@@ -1,0 +1,34 @@
+module.exports = {
+  extends: '../../../.eslintrc.js',
+  env: {
+    mocha: true,
+  },
+  plugins: ['mocha'],
+  rules: {
+    'mocha/no-exclusive-tests': 'error',
+  },
+  globals: {
+    expect: 'readonly',
+    should: 'readonly',
+    sinon: 'readonly',
+    mount: 'readonly',
+    render: 'readonly',
+    shallow: 'readonly',
+    //* ************************************************
+    // bdd-lazy-var
+    //
+    // In order to get around eslint complaining for now:
+    // https://github.com/stalniy/bdd-lazy-var/issues/56#issuecomment-639248242
+    $: 'readonly',
+    its: 'readonly',
+    def: 'readonly',
+    subject: 'readonly',
+    get: 'readonly',
+    sharedExamplesFor: 'readonly',
+    includeExamplesFor: 'readonly',
+    itBehavesLike: 'readonly',
+    is: 'readonly',
+    //
+    //* ************************************************
+  },
+}

--- a/packages/anvil-embed-frame/test/mocha.js
+++ b/packages/anvil-embed-frame/test/mocha.js
@@ -1,0 +1,6 @@
+const parentMochaConfig = require('../../../test/mocha')
+
+module.exports = {
+  ...parentMochaConfig,
+  spec: './test/src/**/*.test.js',
+}

--- a/packages/anvil-embed-frame/test/src/index.test.js
+++ b/packages/anvil-embed-frame/test/src/index.test.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import AnvilEmbedFrame from '../../src/index'
+
+describe('AnvilEmbedFrame', function () {
+  def('handleEvent', () => sinon.spy())
+  def('anvilURL', 'https://app.useanvil.com')
+  def('enableDefaultStyles', true)
+
+  def('render', () => shallow(
+    <AnvilEmbedFrame
+      iframeURL="http://localhost"
+      onEvent={$.handleEvent}
+      anvilURL={$.anvilURL}
+      enableDefaultStyles={$.enableDefaultStyles}
+    />,
+  ))
+
+  it('renders', async function () {
+    const wrapper = $.render
+    expect(wrapper).to.exist
+    expect(wrapper.find('iframe')).to.exist
+  })
+})

--- a/packages/anvil-embed-frame/test/src/index.test.js
+++ b/packages/anvil-embed-frame/test/src/index.test.js
@@ -20,4 +20,30 @@ describe('AnvilEmbedFrame', function () {
     expect(wrapper).to.exist
     expect(wrapper.find('iframe')).to.exist
   })
+
+  describe('onEvent', function () {
+    it('does not call onEvent when non-anvil url passed in', async function () {
+      const origin = 'https://chess.com'
+      const data = { action: 'forgeComplete' }
+      const wrapper = $.render
+      wrapper.instance().handleEvent({ origin, data })
+      expect($.handleEvent).to.not.have.been.called
+    })
+
+    it('does not call onEvent when non-object data passed in', async function () {
+      const origin = $.anvilURL
+      const data = 'signerComplete'
+      const wrapper = $.render
+      wrapper.instance().handleEvent({ origin, data })
+      expect($.handleEvent).to.not.have.been.called
+    })
+
+    it('calls onEvent successfully', async function () {
+      const origin = $.anvilURL
+      const data = { action: 'castEdit' }
+      const wrapper = $.render
+      wrapper.instance().handleEvent({ origin, data })
+      expect($.handleEvent).to.have.been.calledWith(data)
+    })
+  })
 })

--- a/packages/anvil-embed-frame/webpack.config.js
+++ b/packages/anvil-embed-frame/webpack.config.js
@@ -1,0 +1,48 @@
+const path = require('path')
+
+module.exports = {
+  entry: path.resolve(__dirname, 'src', 'index.js'),
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'index.js',
+    libraryTarget: 'commonjs2',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /(node_modules)/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env', '@babel/preset-react'],
+            plugins: ['@babel/plugin-proposal-class-properties'],
+          },
+        },
+      },
+    ],
+  },
+  resolve: {
+    modules: [
+      path.join(__dirname, 'src'),
+      __dirname,
+      'node_modules',
+    ],
+    extensions: ['*', '.js', '.jsx'],
+  },
+  externals: {
+    // Don't bundle react or react-dom
+    react: {
+      commonjs: 'react',
+      commonjs2: 'react',
+      amd: 'React',
+      root: 'React',
+    },
+    'react-dom': {
+      commonjs: 'react-dom',
+      commonjs2: 'react-dom',
+      amd: 'ReactDOM',
+      root: 'ReactDOM',
+    },
+  },
+}

--- a/packages/react-signature-frame/README.md
+++ b/packages/react-signature-frame/README.md
@@ -1,4 +1,4 @@
-# AnvilSignatureFrame
+# (Deprecated) AnvilSignatureFrame
 
 A very minimal component that allows you to embed [Anvil Etch e-signatures](https://www.useanvil.com/docs/api/e-signatures) in your app with an `iframe`. It will give you information via callbacks through the signing process lifecycle.
 


### PR DESCRIPTION
## Description of the change

Build a new `AnvilEmbedFrame` react component that can be used for embedding Etch e-signatures, Workflows, and Editors, now that the app have a uniform protocol for `window.postMessage(object)`. All events are handled by the `onEvent` callback.

Once this package is published, we can deprecate `@anvil/react-signature-frame` and `@anvilco/react-signature-modal`.

**Works for standalone Etch**
Can be embedded
<img width="1788" alt="Pasted Graphic 4" src="https://user-images.githubusercontent.com/26425671/193341610-519c37b1-eb2a-400f-84e1-c927532710e3.png">

Gets `signerComplete` event
<img width="1788" alt="Pasted Graphic 3" src="https://user-images.githubusercontent.com/26425671/193342937-fdb7cc5b-7b48-4ca7-9cf5-482244a65ea3.png">

Gets `signerError` event
<img width="1788" alt="Pasted Graphic 5" src="https://user-images.githubusercontent.com/26425671/193343005-0c27b736-95a9-4850-a0fb-02c082d0c2d2.png">

**Works for Workflows**
Can be embedded
<img width="1788" alt="Pasted Graphic 8" src="https://user-images.githubusercontent.com/26425671/193343043-84276750-46fd-4268-a088-d31446925bed.png">

Gets `forgeSubmitPage` and `forgeComplete` events
<img width="1788" alt="Pasted Graphic 6" src="https://user-images.githubusercontent.com/26425671/193343124-e9a031ec-aee0-4746-b790-0fffa0217330.png">

**Works for Editors**
Can be embedded
<img width="1788" alt="Pasted Graphic 9" src="https://user-images.githubusercontent.com/26425671/193367753-21c6f25c-bcd4-42e4-9913-15967125fcde.png">
<img width="1788" alt="Pasted Graphic 12" src="https://user-images.githubusercontent.com/26425671/193367769-57e6ad88-c7f5-4e29-b3db-a28162d6af0e.png">
<img width="1788" alt="Pasted Graphic 14" src="https://user-images.githubusercontent.com/26425671/193367774-5c966635-d56b-4e54-abd0-8b0f689e2dc4.png">
<img width="1788" alt="Pasted Graphic 16" src="https://user-images.githubusercontent.com/26425671/193367781-b4ba550f-1234-498b-8663-76aca173d7c6.png">

Gets `embeddedError` event
<img width="1788" alt="Token Used" src="https://user-images.githubusercontent.com/26425671/193367826-e179ce19-28a9-4dbd-aff4-0ec7b8af43f2.png">

Gets `castEdit` event
<img width="1788" alt="Pasted Graphic 10" src="https://user-images.githubusercontent.com/26425671/193367845-cd1309b8-8e8e-404b-9733-edaf4eb54101.png">

Gets `etchPacketSent` event
<img width="1788" alt="Pasted Graphic 13" src="https://user-images.githubusercontent.com/26425671/193367871-6120e7da-c526-4910-8099-6f46b97a2ea3.png">

Gets `weldCreate` event
<img width="1788" alt="Pasted Graphic 15" src="https://user-images.githubusercontent.com/26425671/193367909-2bcf69ec-8d0d-4d42-82f8-5d3bdf8fa755.png">

Gets `weldEdit` event
<img width="1788" alt="Pasted Graphic 17" src="https://user-images.githubusercontent.com/26425671/193367921-ecefb2b2-984d-4261-86e4-d6c3204a729e.png">


## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes anvilco/public-repos#18

## Dev Checklist

- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development
- [ ] No previous tests unrelated to the changed code fail in development
